### PR TITLE
Switch Raspberry to RenderEngineCairo

### DIFF
--- a/code/r_central/ruby_central.cpp
+++ b/code/r_central/ruby_central.cpp
@@ -74,7 +74,7 @@
 #include "../base/core_plugins_settings.h"
 #include "../base/utils.h"
 #if defined (HW_PLATFORM_RASPBERRY)
-#include "../renderer/render_engine_raw.h"
+#include "../renderer/render_engine_cairo.h"
 #endif
 #if defined (HW_PLATFORM_RADXA)
 #include "../renderer/drm_core.h"

--- a/code/renderer/render_engine.cpp
+++ b/code/renderer/render_engine.cpp
@@ -36,7 +36,7 @@
 
 #if defined (HW_PLATFORM_RASPBERRY)
 //#include "render_engine_ovg.h"
-#include "render_engine_raw.h"
+#include "render_engine_cairo.h"
 #endif
 
 #if defined (HW_PLATFORM_RADXA)
@@ -56,7 +56,7 @@ RenderEngine* render_init_engine()
    {
       #if defined (HW_PLATFORM_RASPBERRY)
       s_bRenderEngineSupportsRawFonts = true;
-      s_pRenderEngine = new RenderEngineRaw();
+      s_pRenderEngine = new RenderEngineCairo();
       #endif
       #if defined (HW_PLATFORM_RADXA)
       s_bRenderEngineSupportsRawFonts = true;


### PR DESCRIPTION
## Summary
- render Raspberry Pi cases using the Cairo engine just like Radxa
- include the Cairo renderer in ruby_central for Raspberry builds

## Testing
- `make test_log` *(fails: pcap.h missing)*
- `make tests` *(fails: wiringPi.h missing)*

------
https://chatgpt.com/codex/tasks/task_b_686e5f1c31e0832f81a2c88d02b943c3